### PR TITLE
Initializing Thorlabs Cage Rotator (K10CRM/1) 

### DIFF
--- a/qrsa_prototype/qnode/src/qnode/real_time_controller/device_drivers/configNode.py
+++ b/qrsa_prototype/qnode/src/qnode/real_time_controller/device_drivers/configNode.py
@@ -1,0 +1,67 @@
+import thorlabs_apt_device
+import configparser
+import time
+
+def clearLog(Str):
+    Str = 'RTC '+'End Node:'
+
+#def configDevice
+logStr = ''
+confFilePath = "device.config"
+try:
+    confFile = open(confFilePath)
+except FileNotFoundError:
+    logStr += '(ERROR) Could not find the configuration file' + confFilePath
+    print(logStr)
+    exit()
+
+except OSError:
+    logStr += 'OS Error while reading the configuration file'
+    print(logStr)
+    exit()
+
+
+with confFile:
+    devConfig = configparser.ConfigParser()
+    devConfig.read_file(confFile)
+
+    # GET QWP rotator informaion
+    # DeviceType (eg. Thorlabs K10CR1M) and its SerialNumber are sufficient to connect the device
+    qwpDevType = devConfig.get('ENDNODE CONFIG', 'EN_QWP_ROTATOR')
+    print(qwpDevType)
+
+    if qwpDevType != 'K10CR1M':
+        clearLog(logStr)
+        logStr += 'Unknown Optical device for rotating Quarter WavePlate'
+        print(logStr)
+        exit()
+
+    else:
+        qwpDevSerial =  devConfig.get('ENDNODE CONFIG', 'EN_QWP_ROTATOR_SN')
+        print('Initializing qwb with SerialNo:' + qwpDevSerial)
+        qwpConn = thorlabs_apt_device.APTDevice_Motor(serial_number=qwpDevSerial)
+        #qwpConn.open()
+        #qwpConn.open()
+
+        qwpConn.identify()
+        #time.sleep(10)
+        #qwpConn.close()
+
+
+    # GET HWP rotator informaion
+    # DeviceType (eg. Thorlabs K10CR1M) and its SerialNumber are sufficient to connect the device
+    hwpDevType = devConfig.get('ENDNODE CONFIG', 'EN_HWP_ROTATOR')
+    print(hwpDevType)
+
+    if hwpDevType != 'K10CR1M':
+        clearLog(logStr)
+        logStr += 'Unknown Optical device for rotating Half WavePlate'
+        print(logStr)
+        exit()
+
+    else:
+        hwpDevSerial =  devConfig.get('ENDNODE CONFIG', 'EN_HWP_ROTATOR_SN')
+        print('Initializing hwb with SerialNo:' + hwpDevSerial)
+
+        hwpConn = thorlabs_apt_device.APTDevice_Motor(serial_number=hwpDevSerial)
+        hwpConn.identify()

--- a/qrsa_prototype/qnode/src/qnode/real_time_controller/device_drivers/device.config
+++ b/qrsa_prototype/qnode/src/qnode/real_time_controller/device_drivers/device.config
@@ -1,0 +1,10 @@
+[ENDNODE CONFIG]
+#Devie Name for chanhing HWP in the end node
+EN_HWP_ROTATOR = K10CR1M
+# Serial Number of Rotation Cage used for Half Waveplate
+EN_HWP_ROTATOR_SN  = 55357944
+
+#Devie Name for chanhing QWP in the end node
+EN_QWP_ROTATOR = K10CR1M
+# Serial Number of Rotation Cage used for Half Waveplate
+EN_QWP_ROTATOR_SN  = 55357924

--- a/qrsa_prototype/qnode/src/qnode/real_time_controller/device_drivers/rotation_mounts/thorlabs_k10cr1m/__init__.py
+++ b/qrsa_prototype/qnode/src/qnode/real_time_controller/device_drivers/rotation_mounts/thorlabs_k10cr1m/__init__.py
@@ -1,0 +1,1 @@
+from qnode.real_time_controller.device_drivers.rotation_mounts.thorlabs_k10cr1m.k10cr1m import k10cr1m

--- a/qrsa_prototype/qnode/src/qnode/real_time_controller/device_drivers/rotation_mounts/thorlabs_k10cr1m/k10cr1m.py
+++ b/qrsa_prototype/qnode/src/qnode/real_time_controller/device_drivers/rotation_mounts/thorlabs_k10cr1m/k10cr1m.py
@@ -1,0 +1,11 @@
+# This is the test libray written by QITF/SFC-AQUA team
+#    for controlling the Thorlabs K10CR1/M rotation cage:
+#    Note that this is not the offical driver from Thorlabs
+
+import serial
+
+class K10CR1M:
+    """This is the instantiate for Thorlabs K10CR1M"
+       Parameters:
+    """
+    #def __init__(self, port, serial_number):


### PR DESCRIPTION
For changing the measurement basis, we need to rotate HWP (half waveplate) and QWP (quarter waveplate) at the end nodes. Here is the initialization script for Thorlabs cage rotators (K10CRM/1)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/qrsa/19)
<!-- Reviewable:end -->
